### PR TITLE
Add more PPX skip rules

### DIFF
--- a/src/build/parse.rs
+++ b/src/build/parse.rs
@@ -317,9 +317,14 @@ fn path_to_ast_extension(path: &Path) -> &str {
 fn include_ppx(flag: &str, contents: &str) -> bool {
     if flag.contains("bisect") {
         return std::env::var("BISECT_ENABLE").is_ok();
-    } else if flag.contains("graphql-ppx") && !contents.contains("%graphql") {
+    } else if (flag.contains("graphql-ppx") || flag.contains("graphql_ppx")) && !contents.contains("%graphql")
+    {
         return false;
     } else if flag.contains("spice") && !contents.contains("@spice") {
+        return false;
+    } else if flag.contains("rescript-relay") && !contents.contains("%relay") {
+        return false;
+    } else if flag.contains("re-formality") && !contents.contains("%form") {
         return false;
     }
     return true;


### PR DESCRIPTION
This adds skip rules for the following PPX:es:

- Older versions of `graphql_ppx`
- `rescript-relay`
- `re-formality`

Side note - I tested a regexp approach extracting all extension points instead of running `.contains` on the full string for each PPX. It gave a very modest speed increase, so probably not worth pursuing now.